### PR TITLE
Switch to TextInputEditText class

### DIFF
--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -12,7 +12,7 @@
         android:layout_height="wrap_content"
         android:layout_marginBottom="10dp" >
 
-        <EditText
+        <android.support.design.widget.TextInputEditText
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:id="@+id/lEditEmail"
@@ -28,7 +28,7 @@
         android:layout_height="wrap_content"
         android:layout_marginBottom="10dp" >
 
-        <EditText
+        <android.support.design.widget.TextInputEditText
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:id="@+id/lEditPassword"


### PR DESCRIPTION
Resolve warning in Android Studio:
`EditText added is not a TextInputEditText. Please switch to using that class instead` in activity_login.xml

Using the class is also recommended here: https://developer.android.com/reference/android/support/design/widget/TextInputLayout